### PR TITLE
Add rollup for bundling and update build script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "my-awesome-package",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7897,6 +7897,24 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
+      }
+    },
+    "rollup": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.30.0.tgz",
+      "integrity": "sha512-j4K1hUZfgFM03DUpayd3c7kZW+2wDbI6rj7ssQxpCpL1vsGpaM0vSorxBuePFwQDFq9O2DI6AOQbm174Awsq4w==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.1.2"
+      },
+      "dependencies": {
+        "fsevents": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+          "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "run-async": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:coverage": "cross-env BABEL_ENV= NODE_ENV=test nyc --reporter=lcov --reporter=text-summary mocha --require @babel/register \"tests/**/*.tests.js\"",
     "test:watch": "npm test -- --watch",
     "docs": "jsdoc --readme README.md ./lib/*.js -d ./docs && jsdoc2md ./lib/*.js > ./api.md",
-    "build": "rm -rf ./dist/** && babel lib --out-dir ./dist --ignore *.tests.js --source-maps",
+    "build": "rm -rf ./dist/** && rollup -c && babel ./dist/index.js --out-dir ./dist --source-maps",
     "build:min": "minify ./dist/index.js --out-file ./dist/index.min.js --mangle.keepFnName --mangle.keepClassName --",
     "build:full": "npm run docs && npm run build && npm run build:min",
     "build:ci": "npm run lint && npm run test && npm run build:full"
@@ -62,6 +62,7 @@
     "jsdoc-to-markdown": "^5.0.3",
     "mocha": "^7.1.1",
     "nyc": "^15.0.1",
+    "rollup": "^2.30.0",
     "snazzy": "^8.0.0",
     "standard": "^14.3.3"
   }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test:coverage": "cross-env BABEL_ENV= NODE_ENV=test nyc --reporter=lcov --reporter=text-summary mocha --require @babel/register \"tests/**/*.tests.js\"",
     "test:watch": "npm test -- --watch",
     "docs": "jsdoc --readme README.md ./lib/*.js -d ./docs && jsdoc2md ./lib/*.js > ./api.md",
-    "build": "rm -rf ./dist/** && rollup -c && babel ./dist/index.js --out-dir ./dist --source-maps",
+    "build": "npm run build:merge && babel ./dist/index.js --out-dir ./dist --source-maps",
+    "build:merge": "rm -rf ./dist/** && rollup lib/index.js --file dist/index.js --format 'cjs'",
     "build:min": "minify ./dist/index.js --out-file ./dist/index.min.js --mangle.keepFnName --mangle.keepClassName --",
     "build:full": "npm run docs && npm run build && npm run build:min",
     "build:ci": "npm run lint && npm run test && npm run build:full"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,0 @@
-export default {
-    input: 'lib/index.js',
-    output: {
-      file: 'dist/index.js',
-      format: 'cjs',
-    }
-  };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,7 @@
+export default {
+    input: 'lib/index.js',
+    output: {
+      file: 'dist/index.js',
+      format: 'cjs',
+    }
+  };


### PR DESCRIPTION
I propose to include rollup in the following way:
rollup files starting from lib/index.js into dist/index.js -> babel dist/index.js and produce source maps.

rollup.config.json contains rollup settings.

What do you think?